### PR TITLE
Remove VS Code extension recommendation

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,7 +7,6 @@
     "esbenp.prettier-vscode",
     "oderwat.indent-rainbow",
     "patbenatar.advanced-new-file",
-    "robinbentley.sass-indented",
     "sleistner.vscode-fileutils",
     "yzhang.markdown-all-in-one",
   ]


### PR DESCRIPTION
Plugin is no longer available for download