### PR TITLE
Update Storybook config to load jQuery and Bootstrap JS

### DIFF
--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -4,6 +4,7 @@ import 'happo-plugin-storybook/register';
 
 import WebFont from 'webfontloader';
 import '!style-loader!css-loader!sass-loader!./scss-loader.scss';
+import '!style-loader!css-loader!sass-loader!../node_modules/@fortawesome/fontawesome-free/scss/fontawesome.scss';
 
 import jquery from 'jquery';
 global.$ = jquery;

--- a/.storybook/config.js
+++ b/.storybook/config.js
@@ -5,6 +5,11 @@ import 'happo-plugin-storybook/register';
 import WebFont from 'webfontloader';
 import '!style-loader!css-loader!sass-loader!./scss-loader.scss';
 
+import jquery from 'jquery';
+global.$ = jquery;
+global.jQuery = jquery;
+require('bootstrap');
+
 WebFont.load({
   google: {
     families: ['Roboto:300,400,700', 'sans-serif']

--- a/src/scss/boostrap-asu.scss
+++ b/src/scss/boostrap-asu.scss
@@ -79,8 +79,5 @@
 // @import 'related-links';
 // @import 'thumbnails';
 
-
 //== FontAwesome
-// sass-lint:disable-all
-@import '/node_modules/@fortawesome/fontawesome-free/css/all.min.css';
-// sass-lint:enable-all
+// @import '/node_modules/@fortawesome/fontawesome-free/scss/fontawesome.scss';

--- a/src/scss/boostrap-asu.scss
+++ b/src/scss/boostrap-asu.scss
@@ -9,48 +9,48 @@
 // @import 'variables';
 
 //== Bootstrap Required
-@import "../../node_modules/bootstrap/scss/functions";
-@import "../../node_modules/bootstrap/scss/variables";
-@import "../../node_modules/bootstrap/scss/mixins";
+@import '../../node_modules/bootstrap/scss/functions';
+@import '../../node_modules/bootstrap/scss/variables';
+@import '../../node_modules/bootstrap/scss/mixins';
 
 // To remove values from Bootstrap maps, these must occur between Required and Optional imports.
 // $theme-colors: map-remove($theme-colors, "info", "light", "dark");
 
 //= Bootstrap Scaffolding (optional)
-@import "../../node_modules/bootstrap/scss/root";
-@import "../../node_modules/bootstrap/scss/reboot";
-@import "../../node_modules/bootstrap/scss/type";
-@import "../../node_modules/bootstrap/scss/images";
-@import "../../node_modules/bootstrap/scss/code";
-@import "../../node_modules/bootstrap/scss/grid";
-@import "../../node_modules/bootstrap/scss/tables";
-@import "../../node_modules/bootstrap/scss/forms";
-@import "../../node_modules/bootstrap/scss/buttons";
-@import "../../node_modules/bootstrap/scss/transitions";
-@import "../../node_modules/bootstrap/scss/dropdown";
-@import "../../node_modules/bootstrap/scss/button-group";
-@import "../../node_modules/bootstrap/scss/input-group";
-@import "../../node_modules/bootstrap/scss/custom-forms";
-@import "../../node_modules/bootstrap/scss/nav";
-@import "../../node_modules/bootstrap/scss/navbar";
-@import "../../node_modules/bootstrap/scss/card";
-@import "../../node_modules/bootstrap/scss/breadcrumb";
-@import "../../node_modules/bootstrap/scss/pagination";
-@import "../../node_modules/bootstrap/scss/badge";
-@import "../../node_modules/bootstrap/scss/jumbotron";
-@import "../../node_modules/bootstrap/scss/alert";
-@import "../../node_modules/bootstrap/scss/progress";
-@import "../../node_modules/bootstrap/scss/media";
-@import "../../node_modules/bootstrap/scss/list-group";
-@import "../../node_modules/bootstrap/scss/close";
-@import "../../node_modules/bootstrap/scss/toasts";
-@import "../../node_modules/bootstrap/scss/modal";
-@import "../../node_modules/bootstrap/scss/tooltip";
-@import "../../node_modules/bootstrap/scss/popover";
-@import "../../node_modules/bootstrap/scss/carousel";
-@import "../../node_modules/bootstrap/scss/spinners";
-@import "../../node_modules/bootstrap/scss/utilities";
-@import "../../node_modules/bootstrap/scss/print";
+@import '../../node_modules/bootstrap/scss/root';
+@import '../../node_modules/bootstrap/scss/reboot';
+@import '../../node_modules/bootstrap/scss/type';
+@import '../../node_modules/bootstrap/scss/images';
+@import '../../node_modules/bootstrap/scss/code';
+@import '../../node_modules/bootstrap/scss/grid';
+@import '../../node_modules/bootstrap/scss/tables';
+@import '../../node_modules/bootstrap/scss/forms';
+@import '../../node_modules/bootstrap/scss/buttons';
+@import '../../node_modules/bootstrap/scss/transitions';
+@import '../../node_modules/bootstrap/scss/dropdown';
+@import '../../node_modules/bootstrap/scss/button-group';
+@import '../../node_modules/bootstrap/scss/input-group';
+@import '../../node_modules/bootstrap/scss/custom-forms';
+@import '../../node_modules/bootstrap/scss/nav';
+@import '../../node_modules/bootstrap/scss/navbar';
+@import '../../node_modules/bootstrap/scss/card';
+@import '../../node_modules/bootstrap/scss/breadcrumb';
+@import '../../node_modules/bootstrap/scss/pagination';
+@import '../../node_modules/bootstrap/scss/badge';
+@import '../../node_modules/bootstrap/scss/jumbotron';
+@import '../../node_modules/bootstrap/scss/alert';
+@import '../../node_modules/bootstrap/scss/progress';
+@import '../../node_modules/bootstrap/scss/media';
+@import '../../node_modules/bootstrap/scss/list-group';
+@import '../../node_modules/bootstrap/scss/close';
+@import '../../node_modules/bootstrap/scss/toasts';
+@import '../../node_modules/bootstrap/scss/modal';
+@import '../../node_modules/bootstrap/scss/tooltip';
+@import '../../node_modules/bootstrap/scss/popover';
+@import '../../node_modules/bootstrap/scss/carousel';
+@import '../../node_modules/bootstrap/scss/spinners';
+@import '../../node_modules/bootstrap/scss/utilities';
+@import '../../node_modules/bootstrap/scss/print';
 
 //== Override Scaffolding
 // @import 'scaffolding';


### PR DESCRIPTION
This enables Bootstrap's scripts in the component stories.

Also moved Font Awesome import out of the bootstrap-asu.scss  codebase. FA packages their CSS and SCC in a way that is causing some issues with our bundling setup. Until I figure that out, we should just move FA out to be a peer dependency (a package that we require but don't bundle into our code.)